### PR TITLE
Forced CIFS Unlinking

### DIFF
--- a/BRUSdevice/Logical/Lib/BRUSdevice/CIFSDevChk.st
+++ b/BRUSdevice/Logical/Lib/BRUSdevice/CIFSDevChk.st
@@ -68,11 +68,7 @@ FUNCTION_BLOCK CIFSDevChk
 				IS.fb.devLink.pDevice	:= ADR(IS.par.devName); // name of the created device
 				IS.fb.devLink.enable	:= TRUE;
 			
-				IF Eject THEN
-					Info.Status				:= 'ERR: Connection attempt aborted!';
-					IS.step					:= CIFS_IDLE;
-					IS.fb.devLink.enable	:= FALSE;
-				ELSIF IS.fb.devLink.status = ERR_FUB_BUSY OR IS.fb.devLink.status = ERR_FUB_ENABLE_FALSE THEN
+				IF IS.fb.devLink.status = ERR_FUB_BUSY OR IS.fb.devLink.status = ERR_FUB_ENABLE_FALSE THEN
 					// do nothing, stay in state
 				ELSIF IS.fb.devLink.status = ERR_OK THEN
 					// success, move to grab mem info

--- a/BRUSdevice/Logical/Lib/BRUSdevice/CIFSDevChk.st
+++ b/BRUSdevice/Logical/Lib/BRUSdevice/CIFSDevChk.st
@@ -129,6 +129,12 @@ FUNCTION_BLOCK CIFSDevChk
 		// call device related functions
 		IS.fb.devLink();
 		IS.fb.devUnlink();
+		
+		// reject update commands
+		IF Update AND NOT IS.old.update AND IS.step <> CIFS_IDLE THEN
+			Info.Status			:= 'Update failed - State must be Idle';
+		END_IF
+		
 	END_IF
 	
 	// FUNCTION BLOCK DISABLED AND EJECTED

--- a/BRUSdevice/Logical/Lib/BRUSdevice/CIFSDevChk.st
+++ b/BRUSdevice/Logical/Lib/BRUSdevice/CIFSDevChk.st
@@ -59,7 +59,7 @@ FUNCTION_BLOCK CIFSDevChk
 				ELSIF (Eject OR NOT(Enable)) AND Ready THEN
 					Info.Status			:= 'Disconnecting...';
 					IS.step				:= CIFS_UNLINK;
-				ELSIF NOT Enable THEN
+				ELSIF NOT Enable OR (Update AND NOT IS.old.update) THEN
 					IS.stat.initDone	:= FALSE;
 				END_IF
 			
@@ -133,11 +133,6 @@ FUNCTION_BLOCK CIFSDevChk
 		// call device related functions
 		IS.fb.devLink();
 		IS.fb.devUnlink();
-				
-		// check for update commands
-		IF Update AND NOT IS.old.update THEN
-			IS.stat.initDone		:= FALSE;
-		END_IF
 	END_IF
 	
 	// FUNCTION BLOCK DISABLED AND EJECTED

--- a/BRUSdevice/Logical/Lib/BRUSdevice/IEC.lby
+++ b/BRUSdevice/Logical/Lib/BRUSdevice/IEC.lby
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<?AutomationStudio Version=4.7.4.67 SP?>
-<Library Version="1.01.1" SubType="IEC" xmlns="http://br-automation.co.at/AS/Library">
+<?AutomationStudio Version=4.7.5.60 SP?>
+<Library Version="1.01.2" SubType="IEC" xmlns="http://br-automation.co.at/AS/Library">
   <Files>
     <File Description="Exported data types">Types.typ</File>
     <File Description="Exported constants">Constants.var</File>


### PR DESCRIPTION
I was setting the CIFS Link and Eject inputs based on the page that was selected on the HMI, mimicking what was done for the DMAX:
![image](https://github.com/BnR-US-Midwest/BRUSdevice/assets/97972289/2fb8b89e-0c7b-4a0b-94eb-958e15f6cd82)
![image](https://github.com/BnR-US-Midwest/BRUSdevice/assets/97972289/f01fb170-12d1-4323-adbf-da394a4105c3)

I was getting error `20730: Device already exists` from DevLink when changing the page quickly, because the Eject command was interrupting the CIFS_LINK state. I also notice that the Update command will kick the FUB back to Idle, even if there was a device linked already. These changes force the FUB to finish the Link and execute the Eject, so it doesn't get stuck the device created and no handle for DevUnlink to use.